### PR TITLE
Martin fixed ssh from anywhere, updated to Ubuntu 18.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.backup
 *.tfstate
 .DS_Store
+.terraform/
+scoutsuite-report/

--- a/main.tf
+++ b/main.tf
@@ -75,7 +75,7 @@ resource "aws_security_group" "aws-security" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["212.250.100.150/32"]
+    cidr_blocks = ["${var.ssh_ip}"]
   }
 
   # HTTP access from the VPC

--- a/main.tf
+++ b/main.tf
@@ -70,12 +70,12 @@ resource "aws_security_group" "aws-security" {
   description = "Security group to access instance directly"
   vpc_id      = "${aws_vpc.aws-security.id}"
 
-  # SSH access from anywhere
+  # SSH access from base
   ingress {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["212.250.100.150/32"]
   }
 
   # HTTP access from the VPC

--- a/user-data-web
+++ b/user-data-web
@@ -4,6 +4,8 @@ packages:
  - nginx-full
 
 runcmd:
+ - apt -y update
+ - apt -y upgrade
  - service nginx start
 
 output: { all: '| tee -a /var/log/cloud-init-output.log' }

--- a/variables.tf
+++ b/variables.tf
@@ -13,7 +13,7 @@ variable "environment" {}
 # Ubuntu Precise 12.04 LTS (x64)
 variable "aws_amis" {
   default = {
-    eu-west-1 = "ami-b1cf19c6"
+    eu-west-1 = "ami-0c22b482359ce025f"
     us-east-1 = "ami-de7ab6b6"
     us-west-1 = "ami-3f75767a"
     us-west-2 = "ami-21f78e11"
@@ -28,4 +28,9 @@ variable "zone_id" {
 variable "domain" {
   description = "root domain"
   default     = "learncloudsec.net"
+}
+
+variable "ssh_ip" {
+  description = "source ip for ssh connections to instances"
+  default = "212.250.100.150/32"
 }


### PR DESCRIPTION
Removed 0.0.0.0/0 reference and made it a variable, referencing home base.

Updated image to Ubuntu 18.04

cloud-init now runs apt-update/apt-upgrade at deploy time.

